### PR TITLE
Changing interpreter headers to match polymec.

### DIFF
--- a/polyglot/interpreter_register_polyglot_functions.c
+++ b/polyglot/interpreter_register_polyglot_functions.c
@@ -5,7 +5,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "core/interpreter.h"
 #include "polyglot/import_tetgen_mesh.h"
 #include "polyglot/interpreter_register_polyglot_functions.h"
 #include "polyglot/exodus_file.h"

--- a/polyglot/interpreter_register_polyglot_functions.h
+++ b/polyglot/interpreter_register_polyglot_functions.h
@@ -5,7 +5,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "core/interpreter.h"
+#include "model/interpreter.h"
 
 // Adds Polyglot-supported functions to the given interpreter.
 void interpreter_register_polyglot_functions(interpreter_t* interp);

--- a/polymesher/polymesher.c
+++ b/polymesher/polymesher.c
@@ -126,7 +126,6 @@ int main(int argc, char** argv)
 
     // Set up an interpreter for parsing the input file.
     interp = interpreter_new(NULL);
-    interpreter_register_geometry_functions(interp);
     interpreter_register_polyglot_functions(interp);
     interpreter_register_mesher_functions(interp);
 
@@ -147,7 +146,6 @@ int main(int argc, char** argv)
     if (input != NULL)
     {
       interp = interpreter_new(NULL);
-      interpreter_register_geometry_functions(interp);
       interpreter_register_mesher_functions(interp);
     }
   }

--- a/polymesher/polymesher.c
+++ b/polymesher/polymesher.c
@@ -8,8 +8,7 @@
 #include <strings.h>
 #include "core/polymec.h"
 #include "core/options.h"
-#include "core/interpreter.h"
-#include "geometry/interpreter_register_geometry_functions.h"
+#include "model/interpreter.h"
 #include "polyglot/interpreter_register_polyglot_functions.h"
 
 static void mesher_usage(FILE* stream)

--- a/polymesher/write_gnuplot_points.c
+++ b/polymesher/write_gnuplot_points.c
@@ -10,7 +10,7 @@
 
 #include <string.h>
 #include "core/polymec.h"
-#include "core/interpreter.h"
+#include "model/interpreter.h"
 
 // Lua stuff.
 #include "lua.h"


### PR DESCRIPTION
Since the interpreter class is now located in polymec's model library, we have to change our #includes here.